### PR TITLE
Support 'application/octet-stream' content-type; Handle file names

### DIFF
--- a/example_input.txt
+++ b/example_input.txt
@@ -1,3 +1,4 @@
+https://filesamples.com/samples/image/heic/sample1.heic
 https://images.unsplash.com/photo-1595895032883-25ed0e4df2fd?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb
 https://images.unsplash.com/photo-1595922344471-d4205e7cb618?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb
 https://images.unsplash.com/photo-1595885384307-e0ab59e3d6a3?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb

--- a/lib/imgfetcha.rb
+++ b/lib/imgfetcha.rb
@@ -17,5 +17,6 @@ module Imgfetcha
     downloader.run
   rescue StandardError, NotImplementedError => e
     puts e.class, e.message
+    puts e.backtrace if options[:verbose]
   end
 end

--- a/lib/imgfetcha/arg_parser.rb
+++ b/lib/imgfetcha/arg_parser.rb
@@ -18,7 +18,6 @@ module Imgfetcha
     # rubocop:disable Metrics/MethodLength
     def execute_parser
       OptionParser.new do |opts|
-        # TODO: Update it
         opts.banner = 'Usage: imgfetcha -i INPUT_FILE -o OUTPUT_DIRECTORY'
 
         opts.on('-v', '--[no-]verbose', 'Run verbosely') do |v|

--- a/lib/imgfetcha/file_reader.rb
+++ b/lib/imgfetcha/file_reader.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module Imgfetcha
   class FileReader
     attr_reader :input_file, :result


### PR DESCRIPTION
#12 
- Added HEIC sample
- Added `'application/octet-stream'` content-type support
- Do not append duplicated file type if the name already contains it